### PR TITLE
Create a `/bids` API endpoint 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,16 @@ ENV BUNDLE_PATH /bundle
 
 WORKDIR /app
 
+RUN gem install bundler
+
 ADD Gemfile Gemfile.lock ./
 RUN bundle install
 
 ADD . .
 
+EXPOSE 3000
+
 ENTRYPOINT ["docker/entrypoint.sh"]
-CMD ["bundle", "exec", "rspec", "-f", "d"]
+# CMD ["bundle", "exec", "rspec", "-f", "d"]
+
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
   x86_64-linux-musl
 
 DEPENDENCIES

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -3,5 +3,45 @@
 # Controller for Bids model this will handle the API bids endpoint
 class BidsController < ApplicationController
   def show_bids
+    query_params = bids_params.as_json
+    countries = query_params['countries'].split(',')
+    categories = query_params['categories'].split(',')
+    channels = query_params['channels'].split(',')
+    bids = []
+    countries.each do |country|
+      categories.each do |category|
+        channels.each do |channel|
+          bid = {}
+          bid.merge!(country: country, category: category, channel: channel)
+          amount = find_amount(country, category, channel)
+          bid.merge!(amount)
+          bids.push(bid)
+        end
+      end
+    end
+    result = { "bids": bids }
+    render json: JSON.pretty_generate(result)
+  end
+
+  private
+
+  def find_amount(country, category, channel)
+    query = (Bid.where(country: country).and(Bid.where(category: category)).and(Bid.where(channel: channel))).to_a
+    if query.first.present?
+      {
+        amount: query.flatten.first.amount.to_f.to_s
+      }
+    else
+      {
+        amount: Bid.where(country: country)
+                   .or(Bid.where(country: '*')).and(Bid.where(category: category)
+                   .or(Bid.where(category: '*')))
+                   .and(Bid.where(channel: channel).or(Bid.where(channel: '*'))).first&.amount.to_f.to_s
+      }
+    end
+  end
+
+  def bids_params
+    params.permit(:countries, :categories, :channels)
   end
 end

--- a/app/controllers/bids_controller.rb
+++ b/app/controllers/bids_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Controller for Bids model this will handle the API bids endpoint
+class BidsController < ApplicationController
+  def show_bids
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  
+  get '/bids' , to: 'bids#show_bids'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,23 +2,22 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2021_06_08_100421) do
-
+ActiveRecord::Schema[7.0].define(version: 2021_06_08_100421) do
   create_table "bids", force: :cascade do |t|
     t.string "country"
     t.string "category"
     t.string "channel"
     t.decimal "amount"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,8 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# frozen_string_literal: true
+
+require 'factory_bot_rails'
+
+FactoryBot.create(:bid, country: 'us', category: 'finance', channel: 'ca', amount: 4.0)
+FactoryBot.create(:bid, country: 'uk', category: 'sports', channel: '*', amount: 3.0)
+FactoryBot.create(:bid, country: 'us', category: '*' , channel: '*', amount: 2.0)
+FactoryBot.create(:bid, country: '*', category: '*', channel: '*', amount: 1.0)


### PR DESCRIPTION
The challenge is to create a `/bids` API endpoint that would allow other applications to request the bid amounts for different country, category and channel combinations. The endpoint should accept comma-separated lists of countries, categories and channels as parameters, and return a JSON object containing the array with all the combinations and the amount for each.

Sample request:

```
GET /bids?countries=us,uk&categories=finance,sports&channels=ca,ga
```

And the expected response is:
```
{
  "bids": [
    { 'country': 'us', 'category': 'finance', 'channel': 'ca', 'amount': 4.0 },
    { 'country': 'us', 'category': 'finance', 'channel': 'ga', 'amount': 2.0 },
    { 'country': 'us', 'category': 'sports', 'channel': 'ca', 'amount': 2.0 },
    { 'country': 'us', 'category': 'sports', 'channel': 'ga', 'amount': 2.0 },
    { 'country': 'uk', 'category': 'finance', 'channel': 'ca', 'amount': 1.0 },
    { 'country': 'uk', 'category': 'finance', 'channel': 'ga', 'amount': 1.0 },
    { 'country': 'uk', 'category': 'sports', 'channel': 'ca', 'amount': 3.0 },
    { 'country': 'uk', 'category': 'sports', 'channel': 'ga', 'amount': 3.0 }
  ]
}
```

Steps To Run:-
1. Build the docker image by `docker-compose up -d`
2. Go to images in your docker desktop and run the container giving desired port for output i have used 3000
3. Inside the docker container run `bundle exec rake db:create` and `bundle exec rake db:migrate` along with `bundle exec rake db:seed` OR directly run `bundle exec rake db:setup`
4. hit the APU endpoint `http://localhost:3000/bids?countries=us,uk&categories=finance,sports&channels=ca,ga`
5. It provides the desired output as n Readme
6. Test are also passing.

Note:
Time taken to complete this assignment is 8 hours, i personally feel controller could be refactored using a concern, or we could discuss my soultions in Technical rounds ahead, this provides an working endpoint for the challenge.